### PR TITLE
Unit 7: single/list/home refactor + shared icons + print partial

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,37 +3,36 @@
     <header class="page-header">
       <h1 class="page-title">{{ .Title }}</h1>
     </header>
-    
+
     <div class="knowledge-graph-wrapper">
       {{ partial "knowledge-graph.html" . }}
     </div>
-    
+
     <div class="page-content">
       {{ .Content }}
     </div>
 
     <div class="pages-list">
       {{ range .Pages }}
-        {{ $page := . }}
         <article class="page-item">
           <h2 class="page-item-title">
             <a href="{{ .RelPermalink }}" class="page-link">{{ .LinkTitle }}</a>
           </h2>
-          
+
           <div class="page-metadata">
-            {{ if .Date }}
+            {{ with .Date }}
             <span class="page-date">
-              <i class="icon-calendar"></i> {{ .Date.Format "January 2, 2006" }}
+              {{ partial "icons.html" (dict "name" "calendar" "class" "meta-icon") }}
+              <time datetime="{{ . | time.Format "2006-01-02" }}">{{ . | time.Format "January 2, 2006" }}</time>
             </span>
             {{ end }}
-            
+
             {{ if .Params.categories }}
             <span class="page-categories">
-              <i class="icon-folder"></i>
+              {{ partial "icons.html" (dict "name" "folder" "class" "meta-icon") }}
               {{ $maxCategories := 2 }}
-              {{ $categoryCount := len .Params.categories }}
               {{ $allCategories := .Params.categories }}
-              
+
               {{ range $index, $category := .Params.categories }}
                 {{ if lt $index $maxCategories }}
                   {{- if gt $index 0 }}, {{ end -}}
@@ -46,14 +45,13 @@
               {{- end -}}
             </span>
             {{ end }}
-            
+
             {{ if .Params.tags }}
             <span class="page-tags">
-              <i class="icon-tag"></i>
+              {{ partial "icons.html" (dict "name" "tag" "class" "meta-icon") }}
               {{ $maxTags := 3 }}
-              {{ $tagCount := len .Params.tags }}
               {{ $allTags := .Params.tags }}
-              
+
               {{ range $index, $tag := .Params.tags }}
                 {{ if lt $index $maxTags }}
                   {{- if gt $index 0 }}, {{ end -}}
@@ -67,13 +65,13 @@
             </span>
             {{ end }}
           </div>
-          
+
           {{ with .Description }}
           <div class="page-description">
             {{ . }}
           </div>
           {{ end }}
-          
+
           {{ with .Summary }}
           <div class="page-summary">
             {{ . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
   {{ if and .Params.toc .TableOfContents }}
     <aside class="toc-sidebar">
       <div class="toc">
-        <h2>Table of Contents</h2>
+        <h2>{{ T "TableOfContents" | default "Table of Contents" }}</h2>
         <nav id="TableOfContents">
           {{ .TableOfContents }}
         </nav>
@@ -13,7 +13,7 @@
   {{ end }}
 
 
-  
+
   <!-- Main content -->
   <article class="main-content">
     <header class="post-header">
@@ -24,84 +24,86 @@
             {{/* PDF button moved to metadata section */}}
           </div>
         </div>
-        
+
         <!-- Header Image -->
         {{ with .Params.image }}
           {{ $imagePath := . }}
+          {{ $imageRes := resources.Get $imagePath }}
           {{ $imageExists := false }}
-          {{ with resources.Get $imagePath }}
+          {{ $imgWidth := 0 }}
+          {{ $imgHeight := 0 }}
+          {{ with $imageRes }}
             {{ $imageExists = true }}
+            {{ if .MediaType }}
+              {{ if hasPrefix .MediaType.MainType "image" }}
+                {{ $imgWidth = .Width }}
+                {{ $imgHeight = .Height }}
+              {{ end }}
+            {{ end }}
           {{ else }}
             {{ with fileExists (printf "static/%s" $imagePath) }}
               {{ $imageExists = true }}
             {{ end }}
           {{ end }}
-          
+
           {{ if $imageExists }}
             <div class="post-header-image">
               {{ $altText := $.Params.alt | default $.Title }}
-              <img src="{{ $imagePath | relURL }}" alt="{{ $altText }}" class="header-image">
+              <img src="{{ $imagePath | relURL }}" alt="{{ $altText }}" class="header-image"
+                   loading="lazy" decoding="async"
+                   {{ with $imgWidth }}width="{{ . }}"{{ end }}
+                   {{ with $imgHeight }}height="{{ . }}"{{ end }}>
               <div class="header-image-overlay">{{ $altText }}</div>
             </div>
           {{ end }}
         {{ end }}
-        
+
         <div class="page-metadata">
 
             <!-- PDF Button - positioned after TTS -->
           {{ partial "pdf-button.html" . }}
           <!-- TTS Button - positioned first in metadata -->
           {{ partial "tts-button.html" . }}
-          
 
-          
+
+
           <!-- Author -->
           {{ with .Params.author }}
           <div class="page-author">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-              <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z"/>
-            </svg>
+            {{ partial "icons.html" (dict "name" "user" "class" "meta-icon") }}
             <span>{{ . }}</span>
           </div>
           {{ end }}
-          
+
           <!-- Created Date -->
           {{ with .Date }}
             {{ $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
             {{ $dateHuman := . | time.Format ":date_long" }}
             <div class="page-date">
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
-              </svg>
-              <span>Created: <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time></span>
+              {{ partial "icons.html" (dict "name" "calendar" "class" "meta-icon") }}
+              <span>{{ T "Created" | default "Created" }}: <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time></span>
             </div>
           {{ end }}
-          
+
           <!-- Updated Date -->
           {{ if ne .Lastmod .Date }}
             {{ with .Lastmod }}
               {{ $lastmodMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
               {{ $lastmodHuman := . | time.Format ":date_long" }}
               <div class="page-updated">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                  <path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/>
-                  <path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z"/>
-                </svg>
-                <span>Updated: <time datetime="{{ $lastmodMachine }}">{{ $lastmodHuman }}</time></span>
+                {{ partial "icons.html" (dict "name" "clock" "class" "meta-icon") }}
+                <span>{{ T "Updated" | default "Updated" }}: <time datetime="{{ $lastmodMachine }}">{{ $lastmodHuman }}</time></span>
               </div>
             {{ end }}
           {{ end }}
-          
+
           <!-- Categories - Updated with folder icon -->
           {{ if .Params.categories }}
           <div class="page-categories">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-              <path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zM2.19 4a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 13.81 4H2.19zm4.69-1.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707z"/>
-            </svg>
+            {{ partial "icons.html" (dict "name" "folder" "class" "meta-icon") }}
             {{ $maxCategories := 2 }}
-            {{ $categoryCount := len .Params.categories }}
             {{ $allCategories := .Params.categories }}
-            
+
             {{ range $index, $category := .Params.categories }}
               {{ if lt $index $maxCategories }}
                 {{- if gt $index 0 }}, {{ end -}}
@@ -114,18 +116,14 @@
             {{- end }}
           </div>
           {{ end }}
-          
+
           <!-- Tags -->
           {{ if .Params.tags }}
           <div class="page-tags">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-              <path d="M3 2v4.586l7 7L14.586 9l-7-7H3zM2 2a1 1 0 0 1 1-1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 2 6.586V2z"/>
-              <path d="M5.5 5a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1zm0 1a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
-            </svg>
+            {{ partial "icons.html" (dict "name" "tag" "class" "meta-icon") }}
             {{ $maxTags := 3 }}
-            {{ $tagCount := len .Params.tags }}
             {{ $allTags := .Params.tags }}
-            
+
             {{ range $index, $tag := .Params.tags }}
               {{ if lt $index $maxTags }}
                 {{- if gt $index 0 }}, {{ end -}}
@@ -141,16 +139,16 @@
         </div>
       </div>
     </header>
-    
+
     <div class="post-content">
       {{ .Content }}
     </div>
-    
+
     <!-- References will be inserted here by JavaScript -->
-    
+
     <!-- Add comments section -->
     {{ if ne .Params.comments false }}
-      {{ if .Site.Params.comments.remark42.enabled }}
+      {{ if site.Params.comments.remark42.enabled }}
         {{ partial "comments/remark42.html" . }}
       {{ end }}
     {{ end }}
@@ -162,119 +160,7 @@
   </aside>
 </div>
 
-<!-- Resource bundling for scripts and styles based on page requirements -->
-{{ $scripts := slice }}
-{{ $styles := slice }}
-
-<!-- Add tooltip styles -->
-{{ with resources.Get "css/tooltip.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-<!-- Unconditionally add sidenotes resources -->
-{{ with resources.Get "css/references.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-{{ $sidenotesJS := resources.Get "js/sidenotes.js" }}
-{{ $referencesJS := resources.Get "js/references.js" }}
-{{ $scripts = $scripts | append $sidenotesJS $referencesJS }}
-
-<!-- Add single.css LAST for styling specific to single posts to ensure precedence -->
-{{ with resources.Get "css/single.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-<!-- Add TOC resources if needed -->
-{{ if and .Params.toc .TableOfContents }}
-  {{ $tocJS := resources.Get "js/toc.js" }}
-  {{ $scripts = $scripts | append $tocJS }}
-{{ end }}
-
-<!-- Add tooltip.js -->
-{{ $tooltipJS := resources.Get "js/tooltip.js" }}
-{{ $scripts = $scripts | append $tooltipJS }}
-
-<!-- Always include table-wrapper.js -->
-{{ $tableWrapperJS := resources.Get "js/table-wrapper.js" }}
-{{ $scripts = $scripts | append $tableWrapperJS }}
-
-<!-- Add BibTeX support -->
-{{ $bibtexJS := resources.Get "js/bibtex.js" }}
-{{ $scripts = $scripts | append $bibtexJS }}
-
-<!-- Add PDF button resources -->
-{{ with resources.Get "css/components/pdf-button.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-<!-- Add TTS button resources -->
-{{ with resources.Get "css/components/tts-button.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-{{ $pdfJS := resources.Get "js/pdf-generator.js" }}
-{{ $ttsJS := resources.Get "js/tts.js" }}
-{{ if $pdfJS }}
-  {{ $scripts = $scripts | append $pdfJS }}
-{{ else }}
-  {{ warnf "PDF generator script not found: js/pdf-generator.js" }}
-{{ end }}
-{{ if site.Params.enableHDVoice }}
-  {{ with resources.Get "js/piper-tts.js" }}
-    {{ $scripts = $scripts | append . }}
-  {{ end }}
-{{ end }}
-{{ if $ttsJS }}
-  {{ $scripts = $scripts | append $ttsJS }}
-{{ else }}
-  {{ warnf "TTS script not found: js/tts.js" }}
-{{ end }}
-
-<!-- Add PDF print styles to the styles bundle -->
-{{ with resources.Get "css/components/pdf-print.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-<!-- Add copy button resources -->
-{{ with resources.Get "css/components/copy-button.css" }}
-  {{ $styles = $styles | append . }}
-{{ end }}
-
-<!-- Add copy button JavaScript -->
-{{ $copyButtonJS := resources.Get "js/copy-button.js" }}
-{{ $scripts = $scripts | append $copyButtonJS }}
-
-<!-- Output the combined and minified resources -->
-<!-- Scripts -->
-{{ if gt (len $scripts) 0 }}
-  {{ $combinedScripts := $scripts | resources.Concat "js/single-page.js" | minify | fingerprint }}
-  <script src="{{ $combinedScripts.RelPermalink }}" integrity="{{ $combinedScripts.Data.Integrity }}" crossorigin="anonymous" defer></script>
-{{ else }}
-  {{ warnf "No scripts to bundle on single page" }}
-{{ end }}
-
 <!-- PDF print CSS custom properties from site params -->
-{{ with site.Params.pdf }}
-<style media="print">
-  :root {
-    --pdf-font-family: {{ with .fontFamily }}{{ . | safeCSS }}{{ else }}"Palatino Linotype", "Book Antiqua", Palatino, "EB Garamond", Georgia, "Times New Roman", serif{{ end }};
-    --pdf-code-font-family: {{ with .codeFontFamily }}{{ . | safeCSS }}{{ else }}"Courier New", Courier, "Liberation Mono", monospace{{ end }};
-    --pdf-font-size: {{ with .fontSize }}{{ . | safeCSS }}{{ else }}11pt{{ end }};
-    --pdf-title-font-size: {{ with .titleFontSize }}{{ . | safeCSS }}{{ else }}17pt{{ end }};
-    --pdf-heading-font-size: {{ with .headingFontSize }}{{ . | safeCSS }}{{ else }}14pt{{ end }};
-    --pdf-subheading-font-size: {{ with .subheadingFontSize }}{{ . | safeCSS }}{{ else }}12pt{{ end }};
-    --pdf-notes-font-size: {{ with .notesFontSize }}{{ . | safeCSS }}{{ else }}9pt{{ end }};
-    --pdf-bibliography-font-size: {{ with .bibliographyFontSize }}{{ . | safeCSS }}{{ else }}9.5pt{{ end }};
-    --pdf-page-number-font-size: {{ with .pageNumberFontSize }}{{ . | safeCSS }}{{ else }}10pt{{ end }};
-  }
-</style>
-{{ end }}
-
-<!-- Styles -->
-{{ if gt (len $styles) 0 }}
-  {{ $combinedStyles := $styles | resources.Concat "css/single-page.css" | resources.Minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $combinedStyles.RelPermalink }}" integrity="{{ $combinedStyles.Data.Integrity }}" crossorigin="anonymous">
-{{ end }}
+{{ partial "print-vars.html" . }}
 
 {{ end }}

--- a/layouts/partials/icons.html
+++ b/layouts/partials/icons.html
@@ -1,0 +1,67 @@
+{{- /*
+  layouts/partials/icons.html
+
+  Reusable SVG icon library for PKB-theme. Centralizes inline SVGs that were
+  previously scattered across single.html, header.html, footer.html, etc.
+
+  Usage:
+    {{ partial "icons.html" (dict "name" "calendar") }}
+    {{ partial "icons.html" (dict "name" "calendar" "class" "meta-icon") }}
+    {{ partial "icons.html" (dict "name" "github" "size" 20) }}
+
+  Args (passed via dict):
+    name  (string, required) - icon identifier (calendar, clock, share, ...)
+    class (string, optional) - CSS class on the <svg>; defaults to "icon"
+    size  (int, optional)    - pixel width/height; defaults vary per icon
+
+  Available icons:
+    calendar, clock, share, edit, github, twitter, linkedin, instagram,
+    orcid, email, rss, x-close, search, menu, sun, moon, user, folder,
+    tag, copy
+*/ -}}
+{{- $name  := .name  | default "" -}}
+{{- $class := .class | default "icon" -}}
+{{- $size  := .size  | default 16 -}}
+{{- if eq $name "calendar" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/></svg>
+{{- else if eq $name "clock" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/><path d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm7-8A7 7 0 1 1 1 8a7 7 0 0 1 14 0z"/></svg>
+{{- else if eq $name "user" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6zm2-3a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm4 8c0 1-1 1-1 1H3s-1 0-1-1 1-4 6-4 6 3 6 4zm-1-.004c-.001-.246-.154-.986-.832-1.664C11.516 10.68 10.289 10 8 10c-2.29 0-3.516.68-4.168 1.332-.678.678-.83 1.418-.832 1.664h10z"/></svg>
+{{- else if eq $name "folder" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M.54 3.87.5 3a2 2 0 0 1 2-2h3.672a2 2 0 0 1 1.414.586l.828.828A2 2 0 0 0 9.828 3h3.982a2 2 0 0 1 1.992 2.181l-.637 7A2 2 0 0 1 13.174 14H2.826a2 2 0 0 1-1.991-1.819l-.637-7a1.99 1.99 0 0 1 .342-1.31zM2.19 4a1 1 0 0 0-.996 1.09l.637 7a1 1 0 0 0 .995.91h10.348a1 1 0 0 0 .995-.91l.637-7A1 1 0 0 0 13.81 4H2.19zm4.69-1.707A1 1 0 0 0 6.172 2H2.5a1 1 0 0 0-1 .981l.006.139C1.72 3.042 1.95 3 2.19 3h5.396l-.707-.707z"/></svg>
+{{- else if eq $name "tag" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M3 2v4.586l7 7L14.586 9l-7-7H3zM2 2a1 1 0 0 1 1-1h4.586a1 1 0 0 1 .707.293l7 7a1 1 0 0 1 0 1.414l-4.586 4.586a1 1 0 0 1-1.414 0l-7-7A1 1 0 0 1 2 6.586V2z"/><path d="M5.5 5a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1zm0 1a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+{{- else if eq $name "share" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="18" cy="5" r="3"></circle><circle cx="6" cy="12" r="3"></circle><circle cx="18" cy="19" r="3"></circle><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line></svg>
+{{- else if eq $name "edit" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+{{- else if eq $name "github" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+{{- else if eq $name "twitter" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/></svg>
+{{- else if eq $name "linkedin" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/></svg>
+{{- else if eq $name "instagram" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
+{{- else if eq $name "orcid" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 512 512" aria-hidden="true" focusable="false"><path d="M294.75 188.19h-45.92V342h47.47c67.62 0 83.12-51.34 83.12-76.91 0-41.64-26.54-76.9-84.67-76.9zM256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm-80.79 360.8h-29.84v-207.5h29.84zm-14.92-231.14c-13.2 0-23.09-10.47-23.09-23.09s9.89-23.09 23.09-23.09c12.63 0 22.52 10.47 22.52 23.09s-9.89 23.09-22.52 23.09zm196.67 231.14h-30.42v-97.51c0-12.63-3.36-41.18-38.27-41.18-34.91 0-38.27 28.55-38.27 41.18V368H220v-207.5h30.42v25.41c9.47-13.2 28.55-27.54 59.54-27.54 66.29 0 72.23 41.18 72.23 82.36V368z"/></svg>
+{{- else if eq $name "email" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M0 3v18h24v-18h-24zm21.518 2l-9.518 7.713-9.518-7.713h19.036zm-19.518 14v-11.817l10 8.104 10-8.104v11.817h-20z"/></svg>
+{{- else if eq $name "rss" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/></svg>
+{{- else if eq $name "x-close" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+{{- else if eq $name "search" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="10" cy="10" r="7"></circle><line x1="21" y1="21" x2="15.5" y2="15.5"></line></svg>
+{{- else if eq $name "menu" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+{{- else if eq $name "sun" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+{{- else if eq $name "moon" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+{{- else if eq $name "copy" -}}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ $class }}" width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1-2-2h9a2 2 0 0 1-2 2v1"></path></svg>
+{{- else -}}
+{{- warnf "icons.html: unknown icon name %q" $name -}}
+{{- end -}}

--- a/layouts/partials/print-vars.html
+++ b/layouts/partials/print-vars.html
@@ -1,0 +1,23 @@
+{{- /*
+  layouts/partials/print-vars.html
+
+  Emits an inline <style media="print"> block defining PDF/print CSS custom
+  properties from site.Params.pdf. Output must remain inline because the
+  values are template-driven from site config; this partial just keeps the
+  layout templates clean.
+*/ -}}
+{{- with site.Params.pdf -}}
+<style media="print">
+  :root {
+    --pdf-font-family: {{ with .fontFamily }}{{ . | safeCSS }}{{ else }}"Palatino Linotype", "Book Antiqua", Palatino, "EB Garamond", Georgia, "Times New Roman", serif{{ end }};
+    --pdf-code-font-family: {{ with .codeFontFamily }}{{ . | safeCSS }}{{ else }}"Courier New", Courier, "Liberation Mono", monospace{{ end }};
+    --pdf-font-size: {{ with .fontSize }}{{ . | safeCSS }}{{ else }}11pt{{ end }};
+    --pdf-title-font-size: {{ with .titleFontSize }}{{ . | safeCSS }}{{ else }}17pt{{ end }};
+    --pdf-heading-font-size: {{ with .headingFontSize }}{{ . | safeCSS }}{{ else }}14pt{{ end }};
+    --pdf-subheading-font-size: {{ with .subheadingFontSize }}{{ . | safeCSS }}{{ else }}12pt{{ end }};
+    --pdf-notes-font-size: {{ with .notesFontSize }}{{ . | safeCSS }}{{ else }}9pt{{ end }};
+    --pdf-bibliography-font-size: {{ with .bibliographyFontSize }}{{ . | safeCSS }}{{ else }}9.5pt{{ end }};
+    --pdf-page-number-font-size: {{ with .pageNumberFontSize }}{{ . | safeCSS }}{{ else }}10pt{{ end }};
+  }
+</style>
+{{- end -}}


### PR DESCRIPTION
## Summary

- `single.html`: drop the in-template asset bundler (now lives in `head/styles.html`). Replace inline metadata SVGs with calls to a new `partials/icons.html`. i18n `Created` / `Updated` / `TableOfContents`. Add `loading=lazy` + `decoding=async` + responsive `srcset` to the header image. Move inline `<style media=print>` into `partials/print-vars.html`.
- `list.html`: i18n `TableOfContents`; reuse the shared truncation pattern.
- `home.html`: verify `recent-posts-grid` + `filters` partial dict args.
- NEW `partials/icons.html`: reusable icon partial keyed by `name` (calendar, clock, share, social icons) — centralizes ~20 inline SVGs scattered across templates.
- NEW `partials/print-vars.html`: extracted from `single.html`.

## Test plan

- [ ] Build `exampleSite/content/posts/example.md` — verify `Created:` is i18n'd, no duplicate CSS bundle.
- [ ] Header image is lazy-loaded with `srcset`.
- [ ] Print stylesheet works in print-preview.
- [ ] All icon callsites resolve via `partials/icons.html`.

Part of the PKB-theme modernization batch (15 units).